### PR TITLE
bugfixes for haversine formula

### DIFF
--- a/ZFHaversine/ZFHaversine.m
+++ b/ZFHaversine/ZFHaversine.m
@@ -66,7 +66,7 @@ static const CGFloat KILOS_TO_FEET = 3280.84;
         _latitude1ToRadians = _latitude1 * DEGRESS_TO_RADIANS;
         _latitude2ToRadians = _latitude2 * DEGRESS_TO_RADIANS;
         _longitude1ToRadians = _longitude1 * DEGRESS_TO_RADIANS;
-        _longitude2ToRadians = _longitude1 * DEGRESS_TO_RADIANS;
+        _longitude2ToRadians = _longitude2 * DEGRESS_TO_RADIANS;
     }
     return self;
 }

--- a/ZFHaversine/ZFHaversine.m
+++ b/ZFHaversine/ZFHaversine.m
@@ -95,9 +95,9 @@ static const CGFloat KILOS_TO_FEET = 3280.84;
 {
     // Implementation of the haversine formula returning distance in kilos.
     
-    CGFloat a = sinf(_longitudeDeltaToRadians/2) * sinf(_latitudeDeltaToRadians/2) + sinf(_longitudeDeltaToRadians/2) * sinf(_longitudeDeltaToRadians/2) * cosf(_latitude1ToRadians) * cos (_latitude2ToRadians);
+    CGFloat a = sinf(_latitudeDeltaToRadians/2) * sinf(_latitudeDeltaToRadians/2) + sinf(_longitudeDeltaToRadians/2) * sinf(_longitudeDeltaToRadians/2) * cosf(_latitude1ToRadians) * cosf (_latitude2ToRadians);
     
-    CGFloat c = 2.0 * atan2(sqrt(a), sqrt(1-a));
+    CGFloat c = 2.0 * asinf(sqrt(a));
   
     return EARTH_RADIUS_IN_KILOS * c;
 }


### PR DESCRIPTION
I found some issues with this implementation while testing. You can reproduce by holding the longitude constant and varying the latitude. The formula in the current implementation always returns 0 for the distance.

``` objective-c
        float refLat = 24.396308f;
        float refLng = -124.848974f;

        ZFHaversine *haversine = [[ZFHaversine alloc] initWithLatitude1:refLat longitude1:refLng latitude2:38.896376f longitude2:refLng];
        float yKm = [haversine kilos];

        haversine = [[ZFHaversine alloc] initWithLatitude1:refLat longitude1:refLng latitude2:refLat longitude2:-77.328688f];
        float xKm = [haversine kilos];

        haversine = [[ZFHaversine alloc] initWithLatitude1:refLat longitude1:refLng latitude2:38.896376f longitude2:-77.328688f];
        float km = [haversine kilos];

        NSLog(@"translate %f %f %f",yKm,xKm,km);
```

I updated the formula based on the wikipedia version https://en.wikipedia.org/wiki/Haversine_formula.

I assume since this has been untouched for a couple years the implementation provided is working fine for your use. But I figured I would offer to contribute back since I found the code handy.
